### PR TITLE
remove default declaration from PresenceDetector implementation

### DIFF
--- a/Grove_Human_Presence_Sensor.cpp
+++ b/Grove_Human_Presence_Sensor.cpp
@@ -408,7 +408,7 @@ PresenceDetector::PresenceDetector(
     AK9753 &sensor, 
     float threshold_presence, 
     float threshold_movement, 
-    int detect_interval = 30) :
+    int detect_interval) :
   m_interval(detect_interval),
   m_threshold_presence(threshold_presence),
   m_threshold_movement(threshold_movement)


### PR DESCRIPTION
I removed the duplicate default parameter declaration in the implementation of PresenceDetector. 
With this, this library can be used in platformIO on esp32. (the declaration was redundant anyway)