### PR TITLE
Fix reorder error if used with platformIO

### DIFF
--- a/Grove_Human_Presence_Sensor.cpp
+++ b/Grove_Human_Presence_Sensor.cpp
@@ -402,8 +402,8 @@ class Smoother {
     }
 
   private:
-    float m_last_marked_value;
     float m_average_weight;
+    float m_last_marked_value;
     float m_average;
 };
 


### PR DESCRIPTION
I get the following error when I use this lib with platformIO:
`\Grove_Human_Presence_Sensor.cpp:406:11: error: 'Smoother::m_average_weight' will be initialized after [-Werror=reorder]
     float m_average_weight;`

These small reordering should fix the issue, so that people can use this lib without modification.